### PR TITLE
Use correct syntax when adding user to groups

### DIFF
--- a/recipes-robot/python-astoria/astoria-config.bb
+++ b/recipes-robot/python-astoria/astoria-config.bb
@@ -19,7 +19,7 @@ SRC_URI = " \
 
 S = "${WORKDIR}"
 
-USERADD_PARAM:${PN} = "-r -G video -G dialout astoria"
+USERADD_PARAM:${PN} = "-r -G video,dialout astoria"
 
 SYSTEMD_AUTO_ENABLE = "enable"
 SYSTEMD_SERVICE:${PN} = "astdiskd.service astmetad.service astprocd.service"


### PR DESCRIPTION
> A list of supplementary groups which the user is also a member of. Each group is separated from the next by a comma, with no intervening whitespace. 

Fixes syntax issue in ce1df0e5440b2980858d9b8eff380856c35dc4fb. Apparently `useradd` only uses the last defined argument, without erroring