### PR TITLE
Add requested python3 library: pillow

### DIFF
--- a/recipes-images/images/srobo-image-robot.bb
+++ b/recipes-images/images/srobo-image-robot.bb
@@ -15,5 +15,6 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     systemd-analyze \
     python3-matplotlib \
     python3-pandas \
+    python3-pillow \
     python3-pyudev \
     "


### PR DESCRIPTION
This library was requested by GDC in Discord. It seems to be a dependency of matplotlib, but let's add it manually for now anyway (#4)